### PR TITLE
Implement the nullable type for PostgreSQL

### DIFF
--- a/lib/petrol.ml
+++ b/lib/petrol.ml
@@ -77,6 +77,7 @@ module Postgres = struct
     let real = Type.real
     let text = Type.text
     let bool = Type.bool
+    let null_ty = Type.null_ty
 
     include Type.Postgres
 

--- a/lib/petrol.mli
+++ b/lib/petrol.mli
@@ -463,6 +463,9 @@ module Postgres : sig
     val time : Ptime.t Type.t
     (** [time] represents the SQL time type. *)
 
+    val null_ty : 'a t -> 'a option t
+    (** [nullable] represents a nullable SQL field type, which generates an option *)
+
     module Numeric = Type.Numeric
 
   end 


### PR DESCRIPTION
It doesn't seem that there is a generic type struct. So this adds `null_ty` for PostgreSQL.